### PR TITLE
Add Team Members Info Page for Lind-WASM

### DIFF
--- a/docs/more/team.md
+++ b/docs/more/team.md
@@ -14,7 +14,7 @@
 | | | | |
 |---|---|---|---|
 |![Adobe Express - file](https://github.com/user-attachments/assets/e0fb7db8-7747-4e75-8087-84270d105346) | ![Resize image project](https://github.com/user-attachments/assets/bb4c0d2e-6c7b-4837-a5d1-b3c002f428d3) | ![Resize image project (1)](https://github.com/user-attachments/assets/bde7db63-76d2-4bdb-84a3-318ab17f3503) | ![Adobe Express - file (1)](https://github.com/user-attachments/assets/38634b62-062d-4289-83fc-c1e3e85470f9) |
-| <b>Nick Renner </b> </br> PhD Candidate, NYU | <b> Yuchen (Dennis) Zhang </b> </br> Post-doctoral research, NYU | <b> Yaxuan (Alice) Wen </b> </br>  PhD Student, NYU | <b> Qianxi Chen </b> </br> Undergraduate Research Lead, NYU|
+| <b>Nick Renner </b> </br> PhD Candidate, NYU | <b> Yuchen (Dennis) Zhang </b> </br> Post-doctoral researcher, NYU | <b> Yaxuan (Alice) Wen </b> </br>  PhD Student, NYU | <b> Qianxi Chen </b> </br> Undergraduate Research Lead, NYU|
 | | | | |
 
 ## Senior Members
@@ -22,5 +22,5 @@
 | | | |
 |---|---|---|
 | ![Resize image project](https://github.com/user-attachments/assets/481577c7-4f5e-4d1a-8ce8-4fcb77eff30b) | ![Resize image project (1)](https://github.com/user-attachments/assets/6501bad0-f598-4ce8-8544-cec08de75e43) |![Resize image project (2)](https://github.com/user-attachments/assets/5f597834-e838-4510-87f1-b3356afcb2d2) |
-| <b> Chinmay Shringi </b> </br> Researcher assistant, NYU | <b> Runbin Yuan </b> </br> Researcher assistant, NYU | <b> Yashaswi Makula </b> </br> Graduate researcher, NYU |   
+| <b> Chinmay Shringi </b> </br> Graduate Student, NYU | <b> Runbin Yuan </b> </br> Undergraduate Student, NYU | <b> Yashaswi Makula </b> </br> Graduate Student, NYU |   
 

--- a/docs/more/team.md
+++ b/docs/more/team.md
@@ -1,1 +1,26 @@
 # Lind-WASM Team at NYU Secure Systems Lab
+
+
+## Advisor
+
+| | 
+|---|
+| ![justin_cappos_360](https://github.com/user-attachments/assets/bcea496b-d47d-4015-8c22-c9ccccb8aea8) |
+| <b>Justin Cappos </b> </br> Professor, NYU |
+
+
+## Leadership
+
+| | | | |
+|---|---|---|---|
+|![Adobe Express - file](https://github.com/user-attachments/assets/e0fb7db8-7747-4e75-8087-84270d105346) | ![Resize image project](https://github.com/user-attachments/assets/bb4c0d2e-6c7b-4837-a5d1-b3c002f428d3) | ![Resize image project (1)](https://github.com/user-attachments/assets/bde7db63-76d2-4bdb-84a3-318ab17f3503) | ![Adobe Express - file (1)](https://github.com/user-attachments/assets/38634b62-062d-4289-83fc-c1e3e85470f9) |
+| <b>Nick Renner </b> </br> PhD Candidate, NYU | <b> Yuchen (Dennis) Zhang </b> </br> Post-doctoral research, NYU | <b> Yaxuan (Alice) Wen </b> </br>  PhD Student, NYU | <b> Qianxi Chen </b> </br> Undergraduate Research Lead, NYU|
+| | | | |
+
+## Senior Members
+
+| | | |
+|---|---|---|
+| ![Resize image project](https://github.com/user-attachments/assets/481577c7-4f5e-4d1a-8ce8-4fcb77eff30b) | ![Resize image project (1)](https://github.com/user-attachments/assets/6501bad0-f598-4ce8-8544-cec08de75e43) |![Resize image project (2)](https://github.com/user-attachments/assets/5f597834-e838-4510-87f1-b3356afcb2d2) |
+| <b> Chinmay Shringi </b> </br> Researcher assistant, NYU | <b> Runbin Yuan </b> </br> Researcher assistant, NYU | <b> Yashaswi Makula </b> </br> Graduate researcher, NYU |   
+


### PR DESCRIPTION

**Description:**  
This PR adds a dedicated team members information page for the **Lind-WASM** project at NYU Secure Systems Lab. The page includes details on the **advisor, leadership team, and senior members** with corresponding images and roles.  

**Changes Introduced:**  
- Added **Advisor** section featuring Professor Justin Cappos.  
- Included **Leadership** section with key members such as Nick Renner, Yuchen (Dennis) Zhang, Yaxuan (Alice) Wen, and Qianxi Chen.  
- Added **Senior Members** section listing Chinmay Shringi, Runbin Yuan, and Yashaswi Makula.  
- Structured content using Markdown tables for a clear and organized presentation.  

**Motivation:**  
This page helps document and showcase the key contributors to the Lind-WASM project, improving transparency and team visibility within the NYU Secure Systems Lab.  

**Screenshots (if applicable):**  
_Include screenshots of the rendered Markdown file if possible._  

**Checklist:**  
- [x] Verified formatting and layout in Markdown preview.  
- [x] Ensured all images load correctly.  
- [x] Checked for accurate team member details.  

**Additional Notes:**  
- Future updates may include more contributors and additional details as the project evolves.  
