### PR TITLE
Add security policy

### DIFF
--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -6,8 +6,12 @@ in [lind-wasm-docs](https://github.com/Lind-Project/lind-wasm-docs). Please
 contribute to the Lind project by submitting issues or pull requests to these
 repositories.
 
-More detailed guidelines about writing code, tests and documentation are below:
+To report a security issue, please refer to the [Security Policy](security.md)!
+
+
+Detailed guidelines about writing code, tests, documentation, and more are below:
 
 * [Rust Style Guide](styleguide.md)
 * [Unit Tests](unit-tests.md)
 * [Adding to the docs](writeDoc.md)
+* [Security Policy](security.md)

--- a/docs/contribute/security.md
+++ b/docs/contribute/security.md
@@ -1,0 +1,7 @@
+# Security Issues and Bugs
+
+Security issues can be reported to maintainers [privately via GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
+
+- [**Report new vulnerability**](https://github.com/Lind-Project/lind-wasm/security/advisories/new)
+
+Please do not use the GitHub issue tracker to submit vulnerability reports. The issue tracker is intended for bug reports and to make feature requests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - Rust style guide: contribute/styleguide.md
     - Unit tests: contribute/unit-tests.md
     - Adding to the docs: contribute/writeDoc.md
+    - Security policy: contribute/security.md
   - More:
     - Maintainers: more/maintainers.md
   - Community: community.md


### PR DESCRIPTION
~blocks on / includes commit from #37~ (merged)

Add security policy document with instructions to confidentially report security
issues, using the corresponding GitHub feature.

For discoverability, the document will be linked to from a global
SECURITY.md file in Lind-Project/.github.