### PR TITLE
Deduplicate usage section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,11 +5,6 @@ theme:
 
 nav:
   - Home: index.md
-  - Using Lind-Wasm:
-    - Compiling programs: use/compile-programs.md
-    - Running programs: use/run-programs.md
-    - Debugging programs: use/debug-programs.md
-    - Examples: use/examples.md
   - Internal Documentation:
     - libc: internal/libc.md
     - Wasmtime: internal/wasmtime.md
@@ -24,6 +19,7 @@ nav:
     - Compile Programs: use/compile-programs.md
     - Debug Programs: use/debug-programs.md
     - Run Programs: use/run-programs.md
+    - Examples: use/examples.md
   - Contributing:
     - contribute/README.md
     - Rust style guide: contribute/styleguide.md


### PR DESCRIPTION
fixes #24

PR #23 copied the "Using Lind-Wasm" section to a "Usage" section.

Differences are:
- "Usage" is further down in the navigation list
- The pages in the sections are ordered differently
- Only "Using Lind-Wasm" has an "Examples" page (which was added later, after the copy)

Assuming some motivation for the copy, I kept "Usage" and removed "Using Lind-Wasm", preserving the "Examples" page (now also under "Usage").

That said, from a UX perspective, it would seem beneficial to make the "Usage" section more prominent in the navigation section, than the sections "Internal Documentation", and maybe "Build System", which are both above "Usage". Does it make sense to move "Build System" into "Usage"? I suggest to ticketize this and discuss/address separately.