### PR TITLE
Fix bullet points on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,11 +11,11 @@ In Old Norse, Old High German and Old English a "lind" is a shield constructed w
 ## Core Concepts
 
 - **Cage**: Lightweight isolation boundary within a process
-  - Can run legacy code (may need recompilation)
-  - Protects and isolates memory
+    - Can run legacy code (may need recompilation)
+    - Protects and isolates memory
 - **Microvisor**: Small POSIX compliant kernel within a process
-  - Provides a POSIX interface
-  - Distinct isolation between cages
+    - Provides a POSIX interface
+    - Distinct isolation between cages
 - **3i (three eye)**: Capability-based POSIX interfaces between cages
 
 ## Technology Overview
@@ -27,12 +27,14 @@ Memory and bookkeeping that encapsulates the idea of a typical OS process, encom
 Can perform trusted operations on descendant cages without requiring code in the microvisor's TCB. Grates can run arbitrary code, with restrictions only placed by grates beneath them. The microvisor implements a grate with access to call into the Linux kernel.
 
 **Inheritance Properties**:
+
 - A child inherits system calls from parent on fork
 - If cage A was forked by cage B, cage A will have the same system call handlers as cage B
 - If grate A was forkinterpose()'d by grate B, grate A inherits B's system call behavior changes
 
 ### 3i System
 The 3i system serves as:
+
 - Central point for all communication between cages
 - Table container for system call routing
 - Security control mechanism for system call interception
@@ -49,6 +51,7 @@ We’ve ported glibc so that it can be compiled to wasm bytecode and linked with
 
 ### RawPOSIX
 Provides normal POSIX system calls including:
+
 - Signals
 - Fork/exec
 - Threading


### PR DESCRIPTION
Add required newlines and indentation on landing page to render bullet points correctly.